### PR TITLE
Added compatibility with stable, bumped version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trait_tests"
 description="A compiler plugin to allow tests to be defined agaist traits."
-version = "0.3.3"
+version = "0.4.3"
 authors = ["Giles Cope <gilescope@gmail.com>"]
 repository = "https://github.com/gilescope/trait_tests"
 readme="README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,6 @@ license="MIT"
 
 [lib]
 proc-macro = true
-crate-type = ["proc-macro"]
-
 
 [dependencies]
 syn="0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trait_tests"
 description="A compiler plugin to allow tests to be defined agaist traits."
-version = "0.4.3"
+version = "0.4.0"
 authors = ["Giles Cope <gilescope@gmail.com>"]
 repository = "https://github.com/gilescope/trait_tests"
 readme="README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(proc_macro)] //proc_macro_lib
-#![crate_type = "proc-macro"]
-
 extern crate proc_macro;
 extern crate proc_macro2;
 extern crate syn;
@@ -269,7 +266,7 @@ fn generate_unique_test_name(
     trait_name: &Path,
     params: &[proc_macro2::TokenStream],
 ) -> Ident {
-    let mut root =quote!(#struct_ident).to_string();
+    let mut root = quote!(#struct_ident).to_string();
     root.push('_');
     root.push_str(&quote!(#trait_name).to_string());
     for param in params {
@@ -317,11 +314,13 @@ fn inject_test_all_method(trait_def: ItemTrait) -> ItemTrait {
 
     let test_all_fn = syn::parse(
         quote!(
-        fn test_all() {
-            #(Self::#test_calls());*
-        }
-    ).into(),
-    ).unwrap();
+            fn test_all() {
+                #(Self::#test_calls());*
+            }
+        )
+        .into(),
+    )
+    .unwrap();
 
     items.push(test_all_fn);
     syn::ItemTrait { items, ..trait_def }


### PR DESCRIPTION
Bumped version and removed the `#![feature(proc_macro)]` line because it's no longer necessary.